### PR TITLE
Support Python3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.9", "3.12"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.9"
 pydantic = "^2.5.2"
 openai = "^1.3.7"
 anthropic = "^0.7.7"

--- a/think/chat.py
+++ b/think/chat.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Iterator
+from typing import Iterator, Optional
 
 
 class Chat:
@@ -11,7 +11,7 @@ class Chat:
 
     messages: list[dict[str, str]]
 
-    def __init__(self, content: str | None = None):
+    def __init__(self, content: Optional[str] = None):
         """
         Initialize a new conversation.
 
@@ -37,7 +37,7 @@ class Chat:
         dedented_lines = [line[indent:].rstrip() for line in lines]
         return "\n".join(line for line in dedented_lines)
 
-    def add(self, role: str, content: str, name: str | None = None) -> "Chat":
+    def add(self, role: str, content: str, name: Optional[str] = None) -> "Chat":
         """
         Add a message to the conversation.
 
@@ -66,7 +66,7 @@ class Chat:
         self.messages.append(message)
         return self
 
-    def system(self, content: str, name: str | None = None) -> "Chat":
+    def system(self, content: str, name: Optional[str] = None) -> "Chat":
         """
         Add a system message to the conversation.
 
@@ -79,7 +79,7 @@ class Chat:
         """
         return self.add("system", content, name)
 
-    def user(self, content: str, name: str | None = None) -> "Chat":
+    def user(self, content: str, name: Optional[str] = None) -> "Chat":
         """
         Add a user message to the conversation.
 
@@ -89,7 +89,7 @@ class Chat:
         """
         return self.add("user", content, name)
 
-    def assistant(self, content: str, name: str | None = None) -> "Chat":
+    def assistant(self, content: str, name: Optional[str] = None) -> "Chat":
         """
         Add an assistant message to the conversation.
 
@@ -99,7 +99,7 @@ class Chat:
         """
         return self.add("assistant", content, name)
 
-    def function(self, content: str, name: str | None = None) -> "Chat":
+    def function(self, content: str, name: Optional[str] = None) -> "Chat":
         """
         Add a function (tool) response to the conversation.
 
@@ -143,7 +143,7 @@ class Chat:
         child.messages = [deepcopy(msg) for msg in self.messages[index:]]
         return child
 
-    def last(self) -> dict[str, str] | None:
+    def last(self) -> Optional[dict[str, str]]:
         """
         Get the last message in the conversation.
 

--- a/think/llm/anthropic.py
+++ b/think/llm/anthropic.py
@@ -81,7 +81,7 @@ class Claude:
         return prompt
 
     @staticmethod
-    def inject_tools(chat: Chat, tools: list | None) -> Chat:
+    def inject_tools(chat: Chat, tools: Optional[list]) -> Chat:
         """
         Inject tool messages into the chat.
 
@@ -119,8 +119,8 @@ To use a tool, return a message in the following JSON format:
         self,
         chat: Chat,
         max_tokens: int = 1000,
-        tools: list | None = None,
-        parser: Callable | None = None,
+        tools: Optional[list] = None,
+        parser: Optional[Callable] = None,
         max_iterations: int = 5,
     ) -> Optional[str]:
         if parser:

--- a/think/llm/openai.py
+++ b/think/llm/openai.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 from os import getenv
 import time
-from typing import Callable
+from typing import Callable, Optional
 
 from openai import OpenAI, OpenAIError
 from openai.types.chat import ChatCompletion
@@ -32,7 +32,7 @@ class ChatGPT:
 
     def __init__(
         self,
-        api_key: str | None = None,
+        api_key: Optional[str] = None,
         model: str = "gpt-4-1106-preview",
         temperature: float = 0.7,
         timeout: int = 120.0,
@@ -99,7 +99,7 @@ class ChatGPT:
     def _call_chatgpt(
         self,
         messages: list[dict[str, str]],
-        tools: list | None = None,
+        tools: Optional[list] = None,
     ) -> ChatCompletion:
         try:
             log.debug(f"Calling ChatGPT with messages: {messages})")
@@ -127,10 +127,10 @@ class ChatGPT:
     def __call__(
         self,
         chat: Chat,
-        tools: list | None = None,
-        parser: Callable | None = None,
+        tools: Optional[list] = None,
+        parser: Optional[Callable] = None,
         max_iterations: int = 5,
-    ) -> str | None:
+    ) -> Optional[str]:
         chat = chat.fork()
 
         for i in range(max_iterations):

--- a/think/parser.py
+++ b/think/parser.py
@@ -1,6 +1,7 @@
 from enum import Enum
 import json
 import re
+from typing import Union, Optional
 
 from pydantic import BaseModel
 
@@ -67,7 +68,7 @@ class CodeBlockParser(MultiCodeBlockParser):
 
 
 class JSONParser:
-    def __init__(self, spec: BaseModel | None = None, strict: bool = True):
+    def __init__(self, spec: Optional[BaseModel] = None, strict: bool = True):
         self.spec = spec
         self.strict = strict or (spec is not None)
 
@@ -75,7 +76,7 @@ class JSONParser:
     def schema(self):
         return self.spec.model_json_schema() if self.spec else None
 
-    def __call__(self, text: str) -> BaseModel | dict | None:
+    def __call__(self, text: str) -> Union[BaseModel, dict, None]:
         text = text.strip()
         if text.startswith("```"):
             try:

--- a/think/tool.py
+++ b/think/tool.py
@@ -1,5 +1,5 @@
 from pydantic import Field, create_model, ValidationError
-from typing import Callable
+from typing import Callable, Union
 import re
 import inspect
 import json
@@ -91,7 +91,7 @@ def create_pydantic_model_from_function(fn: Callable) -> type:
     return model
 
 
-def tool(fn: Callable | str) -> Callable:
+def tool(fn: Union[Callable, str]) -> Callable:
     """
     Decorator to mark a function as a tool
 


### PR DESCRIPTION
Remove Python3.10+ specific syntax for optional/union types so it works on 3.9 as well.